### PR TITLE
Fix server crash when last player suicides

### DIFF
--- a/scripting/ttt_item_c4.sma
+++ b/scripting/ttt_item_c4.sma
@@ -97,12 +97,13 @@ public ttt_gamemode(gamemode)
 	if(gamemode == GAME_ENDED || gamemode == GAME_RESTARTING)
 	{
 		set_pcvar_num(get_cvar_pointer("mp_c4timer"), get_pcvar_num(cvar_c4_default));
-		remove_entity_name("func_bomb_target");
-		remove_entity_name("info_bomb_target");
 	}
 	
 	if(gamemode == GAME_PREPARING || gamemode == GAME_RESTARTING)
 	{
+		remove_entity_name("func_bomb_target");
+		remove_entity_name("info_bomb_target");
+
 		Create_BombTarget();
 
 		if(!g_iItemBought)


### PR DESCRIPTION
Server crashes when last Innocent, Detective or Traitor suicides with a killer entity. Moving those lines fixes that problem.