### PR TITLE
Fix of Backpack (Visual Bug)

### DIFF
--- a/scripting/ttt_item_defarmor.sma
+++ b/scripting/ttt_item_defarmor.sma
@@ -47,6 +47,7 @@ public ttt_gamemode(gamemode)
 		{
 			id = players[num];
 			cs_set_user_armor(id, 0, CsArmorType);
+			cs_set_user_defuse(id, 0);
 		}
 	}
 }


### PR DESCRIPTION
By removing the defuse kit the visual bug of the backpack gets fixed, if the user survives the round with a defuse kit, on the next round he will spawn with it and a C4 Backpack will be on his back.