### PR TITLE
Deathstation causes server crash when owner has left the server

### DIFF
--- a/scripting/ttt_item_deathstation.sma
+++ b/scripting/ttt_item_deathstation.sma
@@ -63,6 +63,18 @@ public ttt_gamemode(gamemode)
 	}
 }
 
+public client_disconnect(id)
+{
+    new iEnt = -1;
+    while((iEnt = find_ent_by_class(iEnt, TTT_DEATHSTATION)) > 0)
+    {
+        if(entity_get_int(iEnt, EV_INT_iuser1) == id)
+        {
+            remove_entity(iEnt);
+        }
+    }
+} 
+
 public ttt_item_selected(id, item, name[], price)
 {
 	if(g_iItem_DeathStation == item)


### PR DESCRIPTION
When a client suicides with a deathstation from somebody who is no longer in the server, the server crashes (Happen in my server), if the bug is not reproduceable (The crash doesn't happen) the fix is useful anyway as if the player is no longer in the server the  placed deathstation has no meaning to be there.